### PR TITLE
Add "Ipc file not found" error

### DIFF
--- a/lib/ethereum/ipc_client.rb
+++ b/lib/ethereum/ipc_client.rb
@@ -20,7 +20,8 @@ module Ethereum
     end
 
     def self.default_path(paths = IPC_PATHS)
-      paths.select { |path| File.exist?(path) }.first || ""
+      path = paths.select { |path| File.exist?(path) }.first
+      path || raise("Ipc file not found. Please pass in the file path explicitly to IpcClient initializer")
     end
 
     def send_single(payload)


### PR DESCRIPTION
Relevant issue: #12 
The fix adds a clear error message instead of "Errno::EINVAL: Invalid argument - connect(2)"
I think it could be useful if any other default path pops up