### PR TITLE
add support for real byte strings

### DIFF
--- a/lib/ethereum/encoder.rb
+++ b/lib/ethereum/encoder.rb
@@ -56,9 +56,9 @@ module Ethereum
     def encode_bytes(value, subtype)
       subtype.nil? ? encode_dynamic_bytes(value) : encode_static_bytes(value)
     end
-    
+
     def encode_static_bytes(value)
-      value.each_char.map {|x| x.ord.to_s(16)}.join("").ljust(64, '0')
+      value.bytes.map {|x| x.to_s(16).rjust(2, '0')}.join("").ljust(64, '0')
     end
 
     def encode_dynamic_bytes(value)
@@ -71,7 +71,7 @@ module Ethereum
     def encode_string(value, _)
       location = encode_uint(@inputs ? size_of_inputs(@inputs) + @tail.size/2 : 32)
       size = encode_uint(value.bytes.size)
-      content = value.bytes.map {|x| x.to_s(16)}.join("").ljust(64, '0')
+      content = value.bytes.map {|x| x.to_s(16).rjust(2, '0')}.join("").ljust(64, '0')
       [location, size + content]
     end
 

--- a/lib/ethereum/formatter.rb
+++ b/lib/ethereum/formatter.rb
@@ -50,7 +50,7 @@ module Ethereum
       return nil if hexstring.nil?
       hexstring.gsub(/^0x/,'').scan(/.{2}/).collect {|x| x.hex}.pack("c*")
     end
-    
+
     def to_utf8(hexstring)
       return nil if hexstring.nil?
       hexstring.gsub(/^0x/,'').scan(/.{2}/).collect {|x| x.hex}.pack("U*").delete("\u0000")
@@ -63,7 +63,7 @@ module Ethereum
 
     def from_utf8(utf8_string)
       return nil if utf8_string.nil?
-      utf8_string.force_encoding('UTF-8').split("").collect {|x| x.ord.to_s(16)}.join("")
+      utf8_string.force_encoding('UTF-8').split("").collect {|x| x.ord.to_s(16).rjust(2, '0')}.join("")
     end
 
     def to_address(hexstring)
@@ -144,4 +144,3 @@ module Ethereum
   end
 
 end
-


### PR DESCRIPTION
this is a fix to add support for actual byte strings containing string-values from \x00 to \x0F.

This fix makes it easier to add actual byte data to a contract and retrieve it:

```
# assign a 32byte hash as actual bytes:
 ["67b176705b46206614219f47a05aee7ae6a3edbe850bbbe214c536b989aea4d2"].pack('H*')#
# return the hash:
contract.call.get_hash.unpack1('H*')
```
will actually return the provided string