### PR TITLE
Updated the instructions

### DIFF
--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -52,7 +52,7 @@ And then execute:
 
 Or install it yourself as:
 
-    $ gem install ethereum.eb
+    $ gem install ethereum.rb
 
 ### Running a node
 


### PR DESCRIPTION
The code was saying:

Or install it yourself as:

    $ gem install ethereum.eb 

It should be ethereum.rb