### PR TITLE
Transaction wait_for_miner fails if the transaction has been already mined

### DIFF
--- a/lib/ethereum/transaction.rb
+++ b/lib/ethereum/transaction.rb
@@ -24,8 +24,8 @@ module Ethereum
       start_time = Time.now
       loop do
         raise Timeout::Error if ((Time.now - start_time) > timeout)
-        sleep 5
         return true if self.mined?
+        sleep 5
       end
     end
 

--- a/lib/ethereum/transaction.rb
+++ b/lib/ethereum/transaction.rb
@@ -1,6 +1,10 @@
 module Ethereum
 
   class Transaction
+
+    DEFAULT_TIMEOUT = 300.seconds
+    DEFAULT_STEP = 5.seconds
+
     attr_accessor :id, :mined, :connection, :input, :input_parameters
 
     def initialize(id, connection, data, input_parameters = [])
@@ -20,12 +24,12 @@ module Ethereum
       @mined = @connection.eth_get_transaction_by_hash(@id)["result"]["blockNumber"].present?
     end
 
-    def wait_for_miner(timeout = 1500.seconds)
+    def wait_for_miner(timeout: DEFAULT_TIMEOUT, step: DEFAULT_STEP)
       start_time = Time.now
       loop do
         raise Timeout::Error if ((Time.now - start_time) > timeout)
         return true if self.mined?
-        sleep 5
+        sleep step
       end
     end
 
@@ -33,4 +37,4 @@ module Ethereum
       Transaction.new(address, connection, nil, nil)
     end
   end
-end 
+end

--- a/lib/ethereum/transaction.rb
+++ b/lib/ethereum/transaction.rb
@@ -22,7 +22,7 @@ module Ethereum
 
     def wait_for_miner(timeout = 1500.seconds)
       start_time = Time.now
-      while self.mined? == false
+      loop do
         raise Timeout::Error if ((Time.now - start_time) > timeout)
         sleep 5
         return true if self.mined?
@@ -33,4 +33,4 @@ module Ethereum
       Transaction.new(address, connection, nil, nil)
     end
   end
-end
+end 


### PR DESCRIPTION
There is a problem when the transaction has already been mined in wait_for_miner that returns nil.
Also sleep sooner makes to wait for no reason. We can check and then wait if hasn't been mined.