### PR TITLE
Fix mined? in deployment class

### DIFF
--- a/lib/ethereum/deployment.rb
+++ b/lib/ethereum/deployment.rb
@@ -39,9 +39,9 @@ module Ethereum
       start_time = Time.now
       loop do
         raise "Transaction #{@id} timed out." if ((Time.now - start_time) > timeout) 
-        sleep step
         yield if block_given?
         return true if deployed?
+        sleep step
       end
     end
 

--- a/lib/ethereum/deployment.rb
+++ b/lib/ethereum/deployment.rb
@@ -18,7 +18,7 @@ module Ethereum
 
     def mined?
       return true if @mined
-      @mined = @connection.get_transaction_by_hash(@id)["result"]["blockNumber"].present? rescue nil
+      @mined = @connection.eth_get_transaction_by_hash(@id)["result"]["blockNumber"].present?
       @mined ||= false
     end
 


### PR DESCRIPTION
In Deployment the method mined? doesn't work, internally raises an exception because lacks the `eth_` part. (A typo that couldn't be seen?)

I also made the same as #28 to return first the result, and then wait if it's needed. Because now we are waiting for no reason. 