### PR TITLE
Simple integration with Truffle

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,15 @@ If you want to create new contract, that is not yet deployed from ABI definition
 contract = Ethereum::Contract.create(name: "MyContract", abi: abi, code: "...")
 ```
 
+### Simple Truffle integration
+
+If you use Truffle to build and deploy contracts, you can pick up the Truffle artifacts to initialize
+a contract. For example, if you have a MyContract in the Truffle directory at `/my/truffle/project`:
+
+```
+contract = Ethereum::Contract.create(name: 'MyContract, truffle: { paths: [ '/my/truffle/project' ] }, client: client, address: '0x01a4d1A62F01ED966646acBfA8BB0b59960D06dd')
+```
+
 ### Interacting with contract
 
 Functions defined in a contract are exposed using the following conventions:

--- a/README.md
+++ b/README.md
@@ -102,7 +102,13 @@ If you use Truffle to build and deploy contracts, you can pick up the Truffle ar
 a contract. For example, if you have a MyContract in the Truffle directory at `/my/truffle/project`:
 
 ```
-contract = Ethereum::Contract.create(name: 'MyContract, truffle: { paths: [ '/my/truffle/project' ] }, client: client, address: '0x01a4d1A62F01ED966646acBfA8BB0b59960D06dd')
+contract = Ethereum::Contract.create(name: "MyContract", truffle: { paths: [ '/my/truffle/project' ] }, client: client, address: '0x01a4d1A62F01ED966646acBfA8BB0b59960D06dd')
+```
+
+The contract factory will attempt to load the deployed address from the Truffle artifacts if the client's network is present:
+
+```
+contract = Ethereum::Contract.create(name: "MyContract", truffle: { paths: [ '/my/truffle/project' ] }, client: client)
 ```
 
 ### Interacting with contract

--- a/lib/ethereum/contract.rb
+++ b/lib/ethereum/contract.rb
@@ -40,7 +40,9 @@ module Ethereum
     # @option opts [String] :code The hex representation of the contract's bytecode.
     # @option opts [Array,String] :abi The contract's ABI; a string is assumed to contain a JSON representation
     #  of the ABI.
-    # @option opts [String] :address The contract's address.
+    # @option opts [String] :address The contract's address; if not present and +:truffle+ is present,
+    #  the method attempts to determine the address from the artifacts' +networks+ key and the client's
+    #  network id.
     # @option opts [String] :name The contract name.
     # @option opts [Integer] :contract_index The index of the contract data in the compiled file.
     # @option opts [Hash] :truffle If this parameter is present, the method uses Truffle information to
@@ -68,6 +70,14 @@ module Ethereum
             # The truffle artifacts store bytecodes with a 0x tag, which we need to remove
             # this may need to be 'deployedBytecode'
             code = (artifacts['bytecode'].start_with?('0x')) ? artifacts['bytecode'][2, artifacts['bytecode'].length] : artifacts['bytecode']
+            unless address
+              address = if client
+                          network_id = client.net_version['result']
+                          (artifacts['networks'][network_id]) ? artifacts['networks'][network_id]['address'] : nil
+                        else
+                          nil
+                        end
+            end
           else
             abi = nil
             code = nil

--- a/spec/ethereum/contract_spec.rb
+++ b/spec/ethereum/contract_spec.rb
@@ -146,4 +146,39 @@ describe Ethereum::Contract do
     it_behaves_like "communicate with node"
   end
 
+  context "truffle" do
+    let(:tpaths) { [ './spec/truffle' ] }
+    
+    it "finds artifacts with explicit path list" do
+      expect(Ethereum::Contract.find_truffle_artifacts('TestContractOne', tpaths)).not_to eql(nil)
+    end
+    
+    it "finds artifacts with implicit path list" do
+      expect(Ethereum::Contract.find_truffle_artifacts('TestContractOne')).to eql(nil)
+      Ethereum::Contract.truffle_paths.concat(tpaths)
+      expect(Ethereum::Contract.find_truffle_artifacts('TestContractOne')).not_to eql(nil)
+      Ethereum::Contract.truffle_paths = []
+    end
+
+    it "loads contract data from the Truffle artifacts" do
+      artifacts = Ethereum::Contract.find_truffle_artifacts('TestContractOne', tpaths)
+      tcontract = Ethereum::Contract.create(name: "TestContractOne", truffle: { paths: tpaths }, client: client, address: address)
+
+      expect(tcontract.parent.code).to eql(artifacts['bytecode'][2, artifacts['bytecode'].length])
+      expect(tcontract.abi).to eql(artifacts['abi'])
+
+      expect(tcontract.call.methods).to include(:counter_for)
+      expect(tcontract.call.methods).to include(:add_counter)
+      expect(tcontract.call.methods).to include(:remove_counter)
+
+      expect(tcontract.transact.methods).to include(:counter_for)
+      expect(tcontract.transact.methods).to include(:add_counter)
+      expect(tcontract.transact.methods).to include(:remove_counter)
+
+      expect(tcontract.transact_and_wait.methods).to include(:counter_for)
+      expect(tcontract.transact_and_wait.methods).to include(:add_counter)
+      expect(tcontract.transact_and_wait.methods).to include(:remove_counter)
+    end
+  end
+
 end

--- a/spec/ethereum/contract_spec.rb
+++ b/spec/ethereum/contract_spec.rb
@@ -7,6 +7,7 @@ describe Ethereum::Contract do
     def default_account() "0x27dcb234fab8190e53e2d949d7b2c37411efb72e" end
     def gas_price() nil end
     def gas_limit() nil end
+    def net_version() {"jsonrpc"=>"2.0", "id"=>1, "result"=>"1234"} end
   end
 
   let(:client) { MockClient.new }
@@ -161,11 +162,14 @@ describe Ethereum::Contract do
     end
 
     it "loads contract data from the Truffle artifacts" do
+      # net_address is from the artifacts file for network id '1234'
+      net_address = '0xc0c32feb41be1f1eba28f3612d3ca7e458974cdb'
       artifacts = Ethereum::Contract.find_truffle_artifacts('TestContractOne', tpaths)
       tcontract = Ethereum::Contract.create(name: "TestContractOne", truffle: { paths: tpaths }, client: client, address: address)
 
       expect(tcontract.parent.code).to eql(artifacts['bytecode'][2, artifacts['bytecode'].length])
       expect(tcontract.abi).to eql(artifacts['abi'])
+      expect(tcontract.address).to eql(address)
 
       expect(tcontract.call.methods).to include(:counter_for)
       expect(tcontract.call.methods).to include(:add_counter)
@@ -178,6 +182,10 @@ describe Ethereum::Contract do
       expect(tcontract.transact_and_wait.methods).to include(:counter_for)
       expect(tcontract.transact_and_wait.methods).to include(:add_counter)
       expect(tcontract.transact_and_wait.methods).to include(:remove_counter)
+
+      tcontract = Ethereum::Contract.create(name: "TestContractOne", truffle: { paths: tpaths }, client: client)
+
+      expect(tcontract.address).to eql(net_address)
     end
   end
 

--- a/spec/truffle/README.md
+++ b/spec/truffle/README.md
@@ -1,0 +1,22 @@
+# Sample Truffle project for testing
+
+This directory contains a simple Truffle project for testing the Truffle integration.
+It has been tested with [Truffle 4](https://github.com/trufflesuite/truffle/releases/tag/v4.0.0)
+and [TestRPC](https://github.com/ethereumjs/testrpc).
+
+### Running Truffle
+
+The project includes the generated artifact files for the TestContractOne contract, so for testing
+purposes you do not need to run Truffle. If you do, you should start TestRPC with a high enough gas
+limit that the migrations don't run out, for example:
+
+```
+testrpc -l 6000000 -m "one two three four"
+```
+(the `-m` flag sets the wallet mnemonic so that accounts are created consistently across restarts).
+
+### Running tests
+
+There is an rspec test context in spec/etereum/contract_spec.rb that exercises the Truffle integration;
+you don't need to be running TestRPC in order to run the rspec tests.
+

--- a/spec/truffle/build/contracts/Migrations.json
+++ b/spec/truffle/build/contracts/Migrations.json
@@ -1,0 +1,827 @@
+{
+  "contractName": "Migrations",
+  "abi": [
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "new_address",
+          "type": "address"
+        }
+      ],
+      "name": "upgrade",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "last_completed_migration",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": true,
+      "inputs": [],
+      "name": "owner",
+      "outputs": [
+        {
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "completed",
+          "type": "uint256"
+        }
+      ],
+      "name": "setCompleted",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    }
+  ],
+  "bytecode": "0x6060604052341561000f57600080fd5b336000806101000a81548173ffffffffffffffffffffffffffffffffffffffff021916908373ffffffffffffffffffffffffffffffffffffffff1602179055506102db8061005e6000396000f300606060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630900f01014610067578063445df0ac146100a05780638da5cb5b146100c9578063fdacd5761461011e575b600080fd5b341561007257600080fd5b61009e600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610141565b005b34156100ab57600080fd5b6100b3610224565b6040518082815260200191505060405180910390f35b34156100d457600080fd5b6100dc61022a565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561012957600080fd5b61013f600480803590602001909190505061024f565b005b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415610220578190508073ffffffffffffffffffffffffffffffffffffffff1663fdacd5766001546040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180828152602001915050600060405180830381600087803b151561020b57600080fd5b6102c65a03f1151561021c57600080fd5b5050505b5050565b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156102ac57806001819055505b505600a165627a7a723058201b9fcb80eb7428035be3fae1d4c92990949ea37f36a65dfa88a622a083e316cd0029",
+  "deployedBytecode": "0x606060405260043610610062576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680630900f01014610067578063445df0ac146100a05780638da5cb5b146100c9578063fdacd5761461011e575b600080fd5b341561007257600080fd5b61009e600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610141565b005b34156100ab57600080fd5b6100b3610224565b6040518082815260200191505060405180910390f35b34156100d457600080fd5b6100dc61022a565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b341561012957600080fd5b61013f600480803590602001909190505061024f565b005b60008060009054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff161415610220578190508073ffffffffffffffffffffffffffffffffffffffff1663fdacd5766001546040518263ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040180828152602001915050600060405180830381600087803b151561020b57600080fd5b6102c65a03f1151561021c57600080fd5b5050505b5050565b60015481565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1681565b6000809054906101000a900473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff163373ffffffffffffffffffffffffffffffffffffffff1614156102ac57806001819055505b505600a165627a7a723058201b9fcb80eb7428035be3fae1d4c92990949ea37f36a65dfa88a622a083e316cd0029",
+  "sourceMap": "25:488:0:-;;;177:58;;;;;;;;220:10;212:5;;:18;;;;;;;;;;;;;;;;;;25:488;;;;;;",
+  "deployedSourceMap": "25:488:0:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;346:165;;;;;;;;;;;;;;;;;;;;;;;;;;;;73:36;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;49:20;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;239:103;;;;;;;;;;;;;;;;;;;;;;;;;;346:165;408:19;160:5;;;;;;;;;;;146:19;;:10;:19;;;142:26;;;441:11;408:45;;459:8;:21;;;481:24;;459:47;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;142:26;346:165;;:::o;73:36::-;;;;:::o;49:20::-;;;;;;;;;;;;;:::o;239:103::-;160:5;;;;;;;;;;;146:19;;:10;:19;;;142:26;;;328:9;301:24;:36;;;;142:26;239:103;:::o",
+  "source": "pragma solidity ^0.4.4;\n\ncontract Migrations {\n  address public owner;\n  uint public last_completed_migration;\n\n  modifier restricted() {\n    if (msg.sender == owner) _;\n  }\n\n  function Migrations() public {\n    owner = msg.sender;\n  }\n\n  function setCompleted(uint completed) restricted public {\n    last_completed_migration = completed;\n  }\n\n  function upgrade(address new_address) restricted public {\n    Migrations upgraded = Migrations(new_address);\n    upgraded.setCompleted(last_completed_migration);\n  }\n}\n",
+  "sourcePath": "/Users/escoffon/eth/ruby/ethereum.rb/spec/truffle/contracts/Migrations.sol",
+  "ast": {
+    "attributes": {
+      "absolutePath": "/Users/escoffon/eth/ruby/ethereum.rb/spec/truffle/contracts/Migrations.sol",
+      "exportedSymbols": {
+        "Migrations": [
+          56
+        ]
+      }
+    },
+    "children": [
+      {
+        "attributes": {
+          "literals": [
+            "solidity",
+            "^",
+            "0.4",
+            ".4"
+          ]
+        },
+        "id": 1,
+        "name": "PragmaDirective",
+        "src": "0:23:0"
+      },
+      {
+        "attributes": {
+          "baseContracts": [
+            null
+          ],
+          "contractDependencies": [
+            null
+          ],
+          "contractKind": "contract",
+          "documentation": null,
+          "fullyImplemented": true,
+          "linearizedBaseContracts": [
+            56
+          ],
+          "name": "Migrations",
+          "scope": 57
+        },
+        "children": [
+          {
+            "attributes": {
+              "constant": false,
+              "name": "owner",
+              "scope": 56,
+              "stateVariable": true,
+              "storageLocation": "default",
+              "type": "address",
+              "value": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "attributes": {
+                  "name": "address",
+                  "type": "address"
+                },
+                "id": 2,
+                "name": "ElementaryTypeName",
+                "src": "49:7:0"
+              }
+            ],
+            "id": 3,
+            "name": "VariableDeclaration",
+            "src": "49:20:0"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "name": "last_completed_migration",
+              "scope": 56,
+              "stateVariable": true,
+              "storageLocation": "default",
+              "type": "uint256",
+              "value": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "attributes": {
+                  "name": "uint",
+                  "type": "uint256"
+                },
+                "id": 4,
+                "name": "ElementaryTypeName",
+                "src": "73:4:0"
+              }
+            ],
+            "id": 5,
+            "name": "VariableDeclaration",
+            "src": "73:36:0"
+          },
+          {
+            "attributes": {
+              "name": "restricted",
+              "visibility": "internal"
+            },
+            "children": [
+              {
+                "attributes": {
+                  "parameters": [
+                    null
+                  ]
+                },
+                "children": [],
+                "id": 6,
+                "name": "ParameterList",
+                "src": "133:2:0"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "falseBody": null
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "commonType": {
+                            "typeIdentifier": "t_address",
+                            "typeString": "address"
+                          },
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "==",
+                          "type": "bool"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "sender",
+                              "referencedDeclaration": null,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [
+                                    null
+                                  ],
+                                  "referencedDeclaration": 152,
+                                  "type": "msg",
+                                  "value": "msg"
+                                },
+                                "id": 7,
+                                "name": "Identifier",
+                                "src": "146:3:0"
+                              }
+                            ],
+                            "id": 8,
+                            "name": "MemberAccess",
+                            "src": "146:10:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 3,
+                              "type": "address",
+                              "value": "owner"
+                            },
+                            "id": 9,
+                            "name": "Identifier",
+                            "src": "160:5:0"
+                          }
+                        ],
+                        "id": 10,
+                        "name": "BinaryOperation",
+                        "src": "146:19:0"
+                      },
+                      {
+                        "id": 11,
+                        "name": "PlaceholderStatement",
+                        "src": "167:1:0"
+                      }
+                    ],
+                    "id": 12,
+                    "name": "IfStatement",
+                    "src": "142:26:0"
+                  }
+                ],
+                "id": 13,
+                "name": "Block",
+                "src": "136:37:0"
+              }
+            ],
+            "id": 14,
+            "name": "ModifierDefinition",
+            "src": "114:59:0"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": true,
+              "modifiers": [
+                null
+              ],
+              "name": "Migrations",
+              "payable": false,
+              "scope": 56,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "attributes": {
+                  "parameters": [
+                    null
+                  ]
+                },
+                "children": [],
+                "id": 15,
+                "name": "ParameterList",
+                "src": "196:2:0"
+              },
+              {
+                "attributes": {
+                  "parameters": [
+                    null
+                  ]
+                },
+                "children": [],
+                "id": 16,
+                "name": "ParameterList",
+                "src": "206:0:0"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "=",
+                          "type": "address"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 3,
+                              "type": "address",
+                              "value": "owner"
+                            },
+                            "id": 17,
+                            "name": "Identifier",
+                            "src": "212:5:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "sender",
+                              "referencedDeclaration": null,
+                              "type": "address"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [
+                                    null
+                                  ],
+                                  "referencedDeclaration": 152,
+                                  "type": "msg",
+                                  "value": "msg"
+                                },
+                                "id": 18,
+                                "name": "Identifier",
+                                "src": "220:3:0"
+                              }
+                            ],
+                            "id": 19,
+                            "name": "MemberAccess",
+                            "src": "220:10:0"
+                          }
+                        ],
+                        "id": 20,
+                        "name": "Assignment",
+                        "src": "212:18:0"
+                      }
+                    ],
+                    "id": 21,
+                    "name": "ExpressionStatement",
+                    "src": "212:18:0"
+                  }
+                ],
+                "id": 22,
+                "name": "Block",
+                "src": "206:29:0"
+              }
+            ],
+            "id": 23,
+            "name": "FunctionDefinition",
+            "src": "177:58:0"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "name": "setCompleted",
+              "payable": false,
+              "scope": 56,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "completed",
+                      "scope": 35,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "uint256",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "uint",
+                          "type": "uint256"
+                        },
+                        "id": 24,
+                        "name": "ElementaryTypeName",
+                        "src": "261:4:0"
+                      }
+                    ],
+                    "id": 25,
+                    "name": "VariableDeclaration",
+                    "src": "261:14:0"
+                  }
+                ],
+                "id": 26,
+                "name": "ParameterList",
+                "src": "260:16:0"
+              },
+              {
+                "attributes": {
+                  "parameters": [
+                    null
+                  ]
+                },
+                "children": [],
+                "id": 29,
+                "name": "ParameterList",
+                "src": "295:0:0"
+              },
+              {
+                "attributes": {
+                  "arguments": [
+                    null
+                  ]
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "argumentTypes": null,
+                      "overloadedDeclarations": [
+                        null
+                      ],
+                      "referencedDeclaration": 14,
+                      "type": "modifier ()",
+                      "value": "restricted"
+                    },
+                    "id": 27,
+                    "name": "Identifier",
+                    "src": "277:10:0"
+                  }
+                ],
+                "id": 28,
+                "name": "ModifierInvocation",
+                "src": "277:10:0"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "=",
+                          "type": "uint256"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 5,
+                              "type": "uint256",
+                              "value": "last_completed_migration"
+                            },
+                            "id": 30,
+                            "name": "Identifier",
+                            "src": "301:24:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 25,
+                              "type": "uint256",
+                              "value": "completed"
+                            },
+                            "id": 31,
+                            "name": "Identifier",
+                            "src": "328:9:0"
+                          }
+                        ],
+                        "id": 32,
+                        "name": "Assignment",
+                        "src": "301:36:0"
+                      }
+                    ],
+                    "id": 33,
+                    "name": "ExpressionStatement",
+                    "src": "301:36:0"
+                  }
+                ],
+                "id": 34,
+                "name": "Block",
+                "src": "295:47:0"
+              }
+            ],
+            "id": 35,
+            "name": "FunctionDefinition",
+            "src": "239:103:0"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "name": "upgrade",
+              "payable": false,
+              "scope": 56,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "new_address",
+                      "scope": 55,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 36,
+                        "name": "ElementaryTypeName",
+                        "src": "363:7:0"
+                      }
+                    ],
+                    "id": 37,
+                    "name": "VariableDeclaration",
+                    "src": "363:19:0"
+                  }
+                ],
+                "id": 38,
+                "name": "ParameterList",
+                "src": "362:21:0"
+              },
+              {
+                "attributes": {
+                  "parameters": [
+                    null
+                  ]
+                },
+                "children": [],
+                "id": 41,
+                "name": "ParameterList",
+                "src": "402:0:0"
+              },
+              {
+                "attributes": {
+                  "arguments": [
+                    null
+                  ]
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "argumentTypes": null,
+                      "overloadedDeclarations": [
+                        null
+                      ],
+                      "referencedDeclaration": 14,
+                      "type": "modifier ()",
+                      "value": "restricted"
+                    },
+                    "id": 39,
+                    "name": "Identifier",
+                    "src": "384:10:0"
+                  }
+                ],
+                "id": 40,
+                "name": "ModifierInvocation",
+                "src": "384:10:0"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "assignments": [
+                        43
+                      ]
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "constant": false,
+                          "name": "upgraded",
+                          "scope": 55,
+                          "stateVariable": false,
+                          "storageLocation": "default",
+                          "type": "contract Migrations",
+                          "value": null,
+                          "visibility": "internal"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "contractScope": null,
+                              "name": "Migrations",
+                              "referencedDeclaration": 56,
+                              "type": "contract Migrations"
+                            },
+                            "id": 42,
+                            "name": "UserDefinedTypeName",
+                            "src": "408:10:0"
+                          }
+                        ],
+                        "id": 43,
+                        "name": "VariableDeclaration",
+                        "src": "408:19:0"
+                      },
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [
+                            null
+                          ],
+                          "type": "contract Migrations",
+                          "type_conversion": true
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_address",
+                                  "typeString": "address"
+                                }
+                              ],
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 56,
+                              "type": "type(contract Migrations)",
+                              "value": "Migrations"
+                            },
+                            "id": 44,
+                            "name": "Identifier",
+                            "src": "430:10:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 37,
+                              "type": "address",
+                              "value": "new_address"
+                            },
+                            "id": 45,
+                            "name": "Identifier",
+                            "src": "441:11:0"
+                          }
+                        ],
+                        "id": 46,
+                        "name": "FunctionCall",
+                        "src": "430:23:0"
+                      }
+                    ],
+                    "id": 47,
+                    "name": "VariableDeclarationStatement",
+                    "src": "408:45:0"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [
+                            null
+                          ],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_uint256",
+                                  "typeString": "uint256"
+                                }
+                              ],
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "member_name": "setCompleted",
+                              "referencedDeclaration": 35,
+                              "type": "function (uint256) external"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [
+                                    null
+                                  ],
+                                  "referencedDeclaration": 43,
+                                  "type": "contract Migrations",
+                                  "value": "upgraded"
+                                },
+                                "id": 48,
+                                "name": "Identifier",
+                                "src": "459:8:0"
+                              }
+                            ],
+                            "id": 50,
+                            "name": "MemberAccess",
+                            "src": "459:21:0"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 5,
+                              "type": "uint256",
+                              "value": "last_completed_migration"
+                            },
+                            "id": 51,
+                            "name": "Identifier",
+                            "src": "481:24:0"
+                          }
+                        ],
+                        "id": 52,
+                        "name": "FunctionCall",
+                        "src": "459:47:0"
+                      }
+                    ],
+                    "id": 53,
+                    "name": "ExpressionStatement",
+                    "src": "459:47:0"
+                  }
+                ],
+                "id": 54,
+                "name": "Block",
+                "src": "402:109:0"
+              }
+            ],
+            "id": 55,
+            "name": "FunctionDefinition",
+            "src": "346:165:0"
+          }
+        ],
+        "id": 56,
+        "name": "ContractDefinition",
+        "src": "25:488:0"
+      }
+    ],
+    "id": 57,
+    "name": "SourceUnit",
+    "src": "0:514:0"
+  },
+  "compiler": {
+    "name": "solc",
+    "version": "0.4.18+commit.9cf6e910.Emscripten.clang"
+  },
+  "networks": {
+    "1509678630978": {
+      "events": {},
+      "links": {},
+      "address": "0x7314c210da848b7da434808616a4d87d5975f37f"
+    }
+  },
+  "schemaVersion": "1.0.1",
+  "updatedAt": "2017-11-03T03:10:36.484Z"
+}

--- a/spec/truffle/build/contracts/TestContractOne.json
+++ b/spec/truffle/build/contracts/TestContractOne.json
@@ -1246,7 +1246,7 @@
     "version": "0.4.18+commit.9cf6e910.Emscripten.clang"
   },
   "networks": {
-    "1509678630978": {
+    "1234": {
       "events": {},
       "links": {},
       "address": "0xc0c32feb41be1f1eba28f3612d3ca7e458974cdb"

--- a/spec/truffle/build/contracts/TestContractOne.json
+++ b/spec/truffle/build/contracts/TestContractOne.json
@@ -1,0 +1,1257 @@
+{
+  "contractName": "TestContractOne",
+  "abi": [
+    {
+      "constant": true,
+      "inputs": [
+        {
+          "name": "_a",
+          "type": "address"
+        }
+      ],
+      "name": "counterFor",
+      "outputs": [
+        {
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "payable": false,
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_from",
+          "type": "address"
+        },
+        {
+          "name": "_counter",
+          "type": "uint32"
+        }
+      ],
+      "name": "removeCounter",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "constant": false,
+      "inputs": [
+        {
+          "name": "_to",
+          "type": "address"
+        },
+        {
+          "name": "_counter",
+          "type": "uint32"
+        }
+      ],
+      "name": "addCounter",
+      "outputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "payable": false,
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    }
+  ],
+  "bytecode": "0x6060604052341561000f57600080fd5b61036a8061001e6000396000f300606060405260043610610057576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680635d0b67741461005c57806363a8b945146100a9578063780c4a73146100f1575b600080fd5b341561006757600080fd5b610093600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610139565b6040518082815260200191505060405180910390f35b34156100b457600080fd5b6100ef600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803563ffffffff16906020019091905050610181565b005b34156100fc57600080fd5b610137600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803563ffffffff16906020019091905050610240565b005b60008060008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050919050565b60648163ffffffff161115151561019757600080fd5b8063ffffffff166000808473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054101515156101ea57600080fd5b8063ffffffff166000808473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825403925050819055505050565b60648163ffffffff161115151561025657600080fd5b6000808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020548163ffffffff166000808573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054011115156102e857600080fd5b8063ffffffff166000808473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254019250508190555050505600a165627a7a72305820c2b25c7c8ce72700347d6035c4a8aa50834bbfd8f66dccd473fbf3d38cbd2d350029",
+  "deployedBytecode": "0x606060405260043610610057576000357c0100000000000000000000000000000000000000000000000000000000900463ffffffff1680635d0b67741461005c57806363a8b945146100a9578063780c4a73146100f1575b600080fd5b341561006757600080fd5b610093600480803573ffffffffffffffffffffffffffffffffffffffff16906020019091905050610139565b6040518082815260200191505060405180910390f35b34156100b457600080fd5b6100ef600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803563ffffffff16906020019091905050610181565b005b34156100fc57600080fd5b610137600480803573ffffffffffffffffffffffffffffffffffffffff1690602001909190803563ffffffff16906020019091905050610240565b005b60008060008373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020549050919050565b60648163ffffffff161115151561019757600080fd5b8063ffffffff166000808473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054101515156101ea57600080fd5b8063ffffffff166000808473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020600082825403925050819055505050565b60648163ffffffff161115151561025657600080fd5b6000808373ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff168152602001908152602001600020548163ffffffff166000808573ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200190815260200160002054011115156102e857600080fd5b8063ffffffff166000808473ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff1681526020019081526020016000206000828254019250508190555050505600a165627a7a72305820c2b25c7c8ce72700347d6035c4a8aa50834bbfd8f66dccd473fbf3d38cbd2d350029",
+  "sourceMap": "26:626:1:-;;;109:41;;;;;;;;26:626;;;;;;",
+  "deployedSourceMap": "26:626:1:-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;156:98;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;464:186;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;264:194;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;156:98;209:7;235:8;:12;244:2;235:12;;;;;;;;;;;;;;;;228:19;;156:98;;;:::o;464:186::-;556:3;544:8;:15;;;;536:24;;;;;;;;597:8;578:27;;:8;:15;587:5;578:15;;;;;;;;;;;;;;;;:27;;570:36;;;;;;;;635:8;616:27;;:8;:15;625:5;616:15;;;;;;;;;;;;;;;;:27;;;;;;;;;;;464:186;;:::o;264:194::-;351:3;339:8;:15;;;;331:24;;;;;;;;402:8;:13;411:3;402:13;;;;;;;;;;;;;;;;390:8;374:24;;:8;:13;383:3;374:13;;;;;;;;;;;;;;;;:24;373:42;365:51;;;;;;;;443:8;426:25;;:8;:13;435:3;426:13;;;;;;;;;;;;;;;;:25;;;;;;;;;;;264:194;;:::o",
+  "source": "pragma solidity ^0.4.17;\n\ncontract TestContractOne {\n    mapping(address => uint256) internal counters;\n\n    function TestContractOne() public {\n    }\n\n    function counterFor(address _a) public view returns (uint256) {\n        return counters[_a];\n    }\n    \n    function addCounter(address _to, uint32 _counter) public {\n        require(_counter <= 100);\n        require((counters[_to] + _counter) > counters[_to]);\n        counters[_to] += _counter;\n    }\n\n    function removeCounter(address _from, uint32 _counter) public {\n        require(_counter <= 100);\n        require(counters[_from] >= _counter);\n        counters[_from] -= _counter;\n    }\n}\n\n",
+  "sourcePath": "/Users/escoffon/eth/ruby/ethereum.rb/spec/truffle/contracts/TestContractOne.sol",
+  "ast": {
+    "attributes": {
+      "absolutePath": "/Users/escoffon/eth/ruby/ethereum.rb/spec/truffle/contracts/TestContractOne.sol",
+      "exportedSymbols": {
+        "TestContractOne": [
+          140
+        ]
+      }
+    },
+    "children": [
+      {
+        "attributes": {
+          "literals": [
+            "solidity",
+            "^",
+            "0.4",
+            ".17"
+          ]
+        },
+        "id": 58,
+        "name": "PragmaDirective",
+        "src": "0:24:1"
+      },
+      {
+        "attributes": {
+          "baseContracts": [
+            null
+          ],
+          "contractDependencies": [
+            null
+          ],
+          "contractKind": "contract",
+          "documentation": null,
+          "fullyImplemented": true,
+          "linearizedBaseContracts": [
+            140
+          ],
+          "name": "TestContractOne",
+          "scope": 141
+        },
+        "children": [
+          {
+            "attributes": {
+              "constant": false,
+              "name": "counters",
+              "scope": 140,
+              "stateVariable": true,
+              "storageLocation": "default",
+              "type": "mapping(address => uint256)",
+              "value": null,
+              "visibility": "internal"
+            },
+            "children": [
+              {
+                "attributes": {
+                  "type": "mapping(address => uint256)"
+                },
+                "children": [
+                  {
+                    "attributes": {
+                      "name": "address",
+                      "type": "address"
+                    },
+                    "id": 59,
+                    "name": "ElementaryTypeName",
+                    "src": "65:7:1"
+                  },
+                  {
+                    "attributes": {
+                      "name": "uint256",
+                      "type": "uint256"
+                    },
+                    "id": 60,
+                    "name": "ElementaryTypeName",
+                    "src": "76:7:1"
+                  }
+                ],
+                "id": 61,
+                "name": "Mapping",
+                "src": "57:27:1"
+              }
+            ],
+            "id": 62,
+            "name": "VariableDeclaration",
+            "src": "57:45:1"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": true,
+              "modifiers": [
+                null
+              ],
+              "name": "TestContractOne",
+              "payable": false,
+              "scope": 140,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "attributes": {
+                  "parameters": [
+                    null
+                  ]
+                },
+                "children": [],
+                "id": 63,
+                "name": "ParameterList",
+                "src": "133:2:1"
+              },
+              {
+                "attributes": {
+                  "parameters": [
+                    null
+                  ]
+                },
+                "children": [],
+                "id": 64,
+                "name": "ParameterList",
+                "src": "143:0:1"
+              },
+              {
+                "attributes": {
+                  "statements": [
+                    null
+                  ]
+                },
+                "children": [],
+                "id": 65,
+                "name": "Block",
+                "src": "143:7:1"
+              }
+            ],
+            "id": 66,
+            "name": "FunctionDefinition",
+            "src": "109:41:1"
+          },
+          {
+            "attributes": {
+              "constant": true,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [
+                null
+              ],
+              "name": "counterFor",
+              "payable": false,
+              "scope": 140,
+              "stateMutability": "view",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "_a",
+                      "scope": 78,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 67,
+                        "name": "ElementaryTypeName",
+                        "src": "176:7:1"
+                      }
+                    ],
+                    "id": 68,
+                    "name": "VariableDeclaration",
+                    "src": "176:10:1"
+                  }
+                ],
+                "id": 69,
+                "name": "ParameterList",
+                "src": "175:12:1"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "",
+                      "scope": 78,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "uint256",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "uint256",
+                          "type": "uint256"
+                        },
+                        "id": 70,
+                        "name": "ElementaryTypeName",
+                        "src": "209:7:1"
+                      }
+                    ],
+                    "id": 71,
+                    "name": "VariableDeclaration",
+                    "src": "209:7:1"
+                  }
+                ],
+                "id": 72,
+                "name": "ParameterList",
+                "src": "208:9:1"
+              },
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "functionReturnParameters": 72
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": true,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "type": "uint256"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 62,
+                              "type": "mapping(address => uint256)",
+                              "value": "counters"
+                            },
+                            "id": 73,
+                            "name": "Identifier",
+                            "src": "235:8:1"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 68,
+                              "type": "address",
+                              "value": "_a"
+                            },
+                            "id": 74,
+                            "name": "Identifier",
+                            "src": "244:2:1"
+                          }
+                        ],
+                        "id": 75,
+                        "name": "IndexAccess",
+                        "src": "235:12:1"
+                      }
+                    ],
+                    "id": 76,
+                    "name": "Return",
+                    "src": "228:19:1"
+                  }
+                ],
+                "id": 77,
+                "name": "Block",
+                "src": "218:36:1"
+              }
+            ],
+            "id": 78,
+            "name": "FunctionDefinition",
+            "src": "156:98:1"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [
+                null
+              ],
+              "name": "addCounter",
+              "payable": false,
+              "scope": 140,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "_to",
+                      "scope": 111,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 79,
+                        "name": "ElementaryTypeName",
+                        "src": "284:7:1"
+                      }
+                    ],
+                    "id": 80,
+                    "name": "VariableDeclaration",
+                    "src": "284:11:1"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "_counter",
+                      "scope": 111,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "uint32",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "uint32",
+                          "type": "uint32"
+                        },
+                        "id": 81,
+                        "name": "ElementaryTypeName",
+                        "src": "297:6:1"
+                      }
+                    ],
+                    "id": 82,
+                    "name": "VariableDeclaration",
+                    "src": "297:15:1"
+                  }
+                ],
+                "id": 83,
+                "name": "ParameterList",
+                "src": "283:30:1"
+              },
+              {
+                "attributes": {
+                  "parameters": [
+                    null
+                  ]
+                },
+                "children": [],
+                "id": 84,
+                "name": "ParameterList",
+                "src": "321:0:1"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [
+                            null
+                          ],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 155,
+                              "type": "function (bool) pure",
+                              "value": "require"
+                            },
+                            "id": 85,
+                            "name": "Identifier",
+                            "src": "331:7:1"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_uint32",
+                                "typeString": "uint32"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": "<=",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [
+                                    null
+                                  ],
+                                  "referencedDeclaration": 82,
+                                  "type": "uint32",
+                                  "value": "_counter"
+                                },
+                                "id": 86,
+                                "name": "Identifier",
+                                "src": "339:8:1"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "hexvalue": "313030",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "subdenomination": null,
+                                  "token": "number",
+                                  "type": "int_const 100",
+                                  "value": "100"
+                                },
+                                "id": 87,
+                                "name": "Literal",
+                                "src": "351:3:1"
+                              }
+                            ],
+                            "id": 88,
+                            "name": "BinaryOperation",
+                            "src": "339:15:1"
+                          }
+                        ],
+                        "id": 89,
+                        "name": "FunctionCall",
+                        "src": "331:24:1"
+                      }
+                    ],
+                    "id": 90,
+                    "name": "ExpressionStatement",
+                    "src": "331:24:1"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [
+                            null
+                          ],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 155,
+                              "type": "function (bool) pure",
+                              "value": "require"
+                            },
+                            "id": 91,
+                            "name": "Identifier",
+                            "src": "365:7:1"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": ">",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isInlineArray": false,
+                                  "isLValue": false,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "type": "uint256"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "commonType": {
+                                        "typeIdentifier": "t_uint256",
+                                        "typeString": "uint256"
+                                      },
+                                      "isConstant": false,
+                                      "isLValue": false,
+                                      "isPure": false,
+                                      "lValueRequested": false,
+                                      "operator": "+",
+                                      "type": "uint256"
+                                    },
+                                    "children": [
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "isConstant": false,
+                                          "isLValue": true,
+                                          "isPure": false,
+                                          "lValueRequested": false,
+                                          "type": "uint256"
+                                        },
+                                        "children": [
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [
+                                                null
+                                              ],
+                                              "referencedDeclaration": 62,
+                                              "type": "mapping(address => uint256)",
+                                              "value": "counters"
+                                            },
+                                            "id": 92,
+                                            "name": "Identifier",
+                                            "src": "374:8:1"
+                                          },
+                                          {
+                                            "attributes": {
+                                              "argumentTypes": null,
+                                              "overloadedDeclarations": [
+                                                null
+                                              ],
+                                              "referencedDeclaration": 80,
+                                              "type": "address",
+                                              "value": "_to"
+                                            },
+                                            "id": 93,
+                                            "name": "Identifier",
+                                            "src": "383:3:1"
+                                          }
+                                        ],
+                                        "id": 94,
+                                        "name": "IndexAccess",
+                                        "src": "374:13:1"
+                                      },
+                                      {
+                                        "attributes": {
+                                          "argumentTypes": null,
+                                          "overloadedDeclarations": [
+                                            null
+                                          ],
+                                          "referencedDeclaration": 82,
+                                          "type": "uint32",
+                                          "value": "_counter"
+                                        },
+                                        "id": 95,
+                                        "name": "Identifier",
+                                        "src": "390:8:1"
+                                      }
+                                    ],
+                                    "id": 96,
+                                    "name": "BinaryOperation",
+                                    "src": "374:24:1"
+                                  }
+                                ],
+                                "id": 97,
+                                "name": "TupleExpression",
+                                "src": "373:26:1"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "type": "uint256"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [
+                                        null
+                                      ],
+                                      "referencedDeclaration": 62,
+                                      "type": "mapping(address => uint256)",
+                                      "value": "counters"
+                                    },
+                                    "id": 98,
+                                    "name": "Identifier",
+                                    "src": "402:8:1"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [
+                                        null
+                                      ],
+                                      "referencedDeclaration": 80,
+                                      "type": "address",
+                                      "value": "_to"
+                                    },
+                                    "id": 99,
+                                    "name": "Identifier",
+                                    "src": "411:3:1"
+                                  }
+                                ],
+                                "id": 100,
+                                "name": "IndexAccess",
+                                "src": "402:13:1"
+                              }
+                            ],
+                            "id": 101,
+                            "name": "BinaryOperation",
+                            "src": "373:42:1"
+                          }
+                        ],
+                        "id": 102,
+                        "name": "FunctionCall",
+                        "src": "365:51:1"
+                      }
+                    ],
+                    "id": 103,
+                    "name": "ExpressionStatement",
+                    "src": "365:51:1"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "+=",
+                          "type": "uint256"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": true,
+                              "type": "uint256"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [
+                                    null
+                                  ],
+                                  "referencedDeclaration": 62,
+                                  "type": "mapping(address => uint256)",
+                                  "value": "counters"
+                                },
+                                "id": 104,
+                                "name": "Identifier",
+                                "src": "426:8:1"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [
+                                    null
+                                  ],
+                                  "referencedDeclaration": 80,
+                                  "type": "address",
+                                  "value": "_to"
+                                },
+                                "id": 105,
+                                "name": "Identifier",
+                                "src": "435:3:1"
+                              }
+                            ],
+                            "id": 106,
+                            "name": "IndexAccess",
+                            "src": "426:13:1"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 82,
+                              "type": "uint32",
+                              "value": "_counter"
+                            },
+                            "id": 107,
+                            "name": "Identifier",
+                            "src": "443:8:1"
+                          }
+                        ],
+                        "id": 108,
+                        "name": "Assignment",
+                        "src": "426:25:1"
+                      }
+                    ],
+                    "id": 109,
+                    "name": "ExpressionStatement",
+                    "src": "426:25:1"
+                  }
+                ],
+                "id": 110,
+                "name": "Block",
+                "src": "321:137:1"
+              }
+            ],
+            "id": 111,
+            "name": "FunctionDefinition",
+            "src": "264:194:1"
+          },
+          {
+            "attributes": {
+              "constant": false,
+              "implemented": true,
+              "isConstructor": false,
+              "modifiers": [
+                null
+              ],
+              "name": "removeCounter",
+              "payable": false,
+              "scope": 140,
+              "stateMutability": "nonpayable",
+              "superFunction": null,
+              "visibility": "public"
+            },
+            "children": [
+              {
+                "children": [
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "_from",
+                      "scope": 139,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "address",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "address",
+                          "type": "address"
+                        },
+                        "id": 112,
+                        "name": "ElementaryTypeName",
+                        "src": "487:7:1"
+                      }
+                    ],
+                    "id": 113,
+                    "name": "VariableDeclaration",
+                    "src": "487:13:1"
+                  },
+                  {
+                    "attributes": {
+                      "constant": false,
+                      "name": "_counter",
+                      "scope": 139,
+                      "stateVariable": false,
+                      "storageLocation": "default",
+                      "type": "uint32",
+                      "value": null,
+                      "visibility": "internal"
+                    },
+                    "children": [
+                      {
+                        "attributes": {
+                          "name": "uint32",
+                          "type": "uint32"
+                        },
+                        "id": 114,
+                        "name": "ElementaryTypeName",
+                        "src": "502:6:1"
+                      }
+                    ],
+                    "id": 115,
+                    "name": "VariableDeclaration",
+                    "src": "502:15:1"
+                  }
+                ],
+                "id": 116,
+                "name": "ParameterList",
+                "src": "486:32:1"
+              },
+              {
+                "attributes": {
+                  "parameters": [
+                    null
+                  ]
+                },
+                "children": [],
+                "id": 117,
+                "name": "ParameterList",
+                "src": "526:0:1"
+              },
+              {
+                "children": [
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [
+                            null
+                          ],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 155,
+                              "type": "function (bool) pure",
+                              "value": "require"
+                            },
+                            "id": 118,
+                            "name": "Identifier",
+                            "src": "536:7:1"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_uint32",
+                                "typeString": "uint32"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": "<=",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [
+                                    null
+                                  ],
+                                  "referencedDeclaration": 115,
+                                  "type": "uint32",
+                                  "value": "_counter"
+                                },
+                                "id": 119,
+                                "name": "Identifier",
+                                "src": "544:8:1"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "hexvalue": "313030",
+                                  "isConstant": false,
+                                  "isLValue": false,
+                                  "isPure": true,
+                                  "lValueRequested": false,
+                                  "subdenomination": null,
+                                  "token": "number",
+                                  "type": "int_const 100",
+                                  "value": "100"
+                                },
+                                "id": 120,
+                                "name": "Literal",
+                                "src": "556:3:1"
+                              }
+                            ],
+                            "id": 121,
+                            "name": "BinaryOperation",
+                            "src": "544:15:1"
+                          }
+                        ],
+                        "id": 122,
+                        "name": "FunctionCall",
+                        "src": "536:24:1"
+                      }
+                    ],
+                    "id": 123,
+                    "name": "ExpressionStatement",
+                    "src": "536:24:1"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "isStructConstructorCall": false,
+                          "lValueRequested": false,
+                          "names": [
+                            null
+                          ],
+                          "type": "tuple()",
+                          "type_conversion": false
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": [
+                                {
+                                  "typeIdentifier": "t_bool",
+                                  "typeString": "bool"
+                                }
+                              ],
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 155,
+                              "type": "function (bool) pure",
+                              "value": "require"
+                            },
+                            "id": 124,
+                            "name": "Identifier",
+                            "src": "570:7:1"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "commonType": {
+                                "typeIdentifier": "t_uint256",
+                                "typeString": "uint256"
+                              },
+                              "isConstant": false,
+                              "isLValue": false,
+                              "isPure": false,
+                              "lValueRequested": false,
+                              "operator": ">=",
+                              "type": "bool"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "isConstant": false,
+                                  "isLValue": true,
+                                  "isPure": false,
+                                  "lValueRequested": false,
+                                  "type": "uint256"
+                                },
+                                "children": [
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [
+                                        null
+                                      ],
+                                      "referencedDeclaration": 62,
+                                      "type": "mapping(address => uint256)",
+                                      "value": "counters"
+                                    },
+                                    "id": 125,
+                                    "name": "Identifier",
+                                    "src": "578:8:1"
+                                  },
+                                  {
+                                    "attributes": {
+                                      "argumentTypes": null,
+                                      "overloadedDeclarations": [
+                                        null
+                                      ],
+                                      "referencedDeclaration": 113,
+                                      "type": "address",
+                                      "value": "_from"
+                                    },
+                                    "id": 126,
+                                    "name": "Identifier",
+                                    "src": "587:5:1"
+                                  }
+                                ],
+                                "id": 127,
+                                "name": "IndexAccess",
+                                "src": "578:15:1"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [
+                                    null
+                                  ],
+                                  "referencedDeclaration": 115,
+                                  "type": "uint32",
+                                  "value": "_counter"
+                                },
+                                "id": 128,
+                                "name": "Identifier",
+                                "src": "597:8:1"
+                              }
+                            ],
+                            "id": 129,
+                            "name": "BinaryOperation",
+                            "src": "578:27:1"
+                          }
+                        ],
+                        "id": 130,
+                        "name": "FunctionCall",
+                        "src": "570:36:1"
+                      }
+                    ],
+                    "id": 131,
+                    "name": "ExpressionStatement",
+                    "src": "570:36:1"
+                  },
+                  {
+                    "children": [
+                      {
+                        "attributes": {
+                          "argumentTypes": null,
+                          "isConstant": false,
+                          "isLValue": false,
+                          "isPure": false,
+                          "lValueRequested": false,
+                          "operator": "-=",
+                          "type": "uint256"
+                        },
+                        "children": [
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "isConstant": false,
+                              "isLValue": true,
+                              "isPure": false,
+                              "lValueRequested": true,
+                              "type": "uint256"
+                            },
+                            "children": [
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [
+                                    null
+                                  ],
+                                  "referencedDeclaration": 62,
+                                  "type": "mapping(address => uint256)",
+                                  "value": "counters"
+                                },
+                                "id": 132,
+                                "name": "Identifier",
+                                "src": "616:8:1"
+                              },
+                              {
+                                "attributes": {
+                                  "argumentTypes": null,
+                                  "overloadedDeclarations": [
+                                    null
+                                  ],
+                                  "referencedDeclaration": 113,
+                                  "type": "address",
+                                  "value": "_from"
+                                },
+                                "id": 133,
+                                "name": "Identifier",
+                                "src": "625:5:1"
+                              }
+                            ],
+                            "id": 134,
+                            "name": "IndexAccess",
+                            "src": "616:15:1"
+                          },
+                          {
+                            "attributes": {
+                              "argumentTypes": null,
+                              "overloadedDeclarations": [
+                                null
+                              ],
+                              "referencedDeclaration": 115,
+                              "type": "uint32",
+                              "value": "_counter"
+                            },
+                            "id": 135,
+                            "name": "Identifier",
+                            "src": "635:8:1"
+                          }
+                        ],
+                        "id": 136,
+                        "name": "Assignment",
+                        "src": "616:27:1"
+                      }
+                    ],
+                    "id": 137,
+                    "name": "ExpressionStatement",
+                    "src": "616:27:1"
+                  }
+                ],
+                "id": 138,
+                "name": "Block",
+                "src": "526:124:1"
+              }
+            ],
+            "id": 139,
+            "name": "FunctionDefinition",
+            "src": "464:186:1"
+          }
+        ],
+        "id": 140,
+        "name": "ContractDefinition",
+        "src": "26:626:1"
+      }
+    ],
+    "id": 141,
+    "name": "SourceUnit",
+    "src": "0:654:1"
+  },
+  "compiler": {
+    "name": "solc",
+    "version": "0.4.18+commit.9cf6e910.Emscripten.clang"
+  },
+  "networks": {
+    "1509678630978": {
+      "events": {},
+      "links": {},
+      "address": "0xc0c32feb41be1f1eba28f3612d3ca7e458974cdb"
+    }
+  },
+  "schemaVersion": "1.0.1",
+  "updatedAt": "2017-11-03T03:10:36.482Z"
+}

--- a/spec/truffle/contracts/Migrations.sol
+++ b/spec/truffle/contracts/Migrations.sol
@@ -1,0 +1,23 @@
+pragma solidity ^0.4.4;
+
+contract Migrations {
+  address public owner;
+  uint public last_completed_migration;
+
+  modifier restricted() {
+    if (msg.sender == owner) _;
+  }
+
+  function Migrations() public {
+    owner = msg.sender;
+  }
+
+  function setCompleted(uint completed) restricted public {
+    last_completed_migration = completed;
+  }
+
+  function upgrade(address new_address) restricted public {
+    Migrations upgraded = Migrations(new_address);
+    upgraded.setCompleted(last_completed_migration);
+  }
+}

--- a/spec/truffle/contracts/TestContractOne.sol
+++ b/spec/truffle/contracts/TestContractOne.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.4.17;
+
+contract TestContractOne {
+    mapping(address => uint256) internal counters;
+
+    function TestContractOne() public {
+    }
+
+    function counterFor(address _a) public view returns (uint256) {
+        return counters[_a];
+    }
+    
+    function addCounter(address _to, uint32 _counter) public {
+        require(_counter <= 100);
+        require((counters[_to] + _counter) > counters[_to]);
+        counters[_to] += _counter;
+    }
+
+    function removeCounter(address _from, uint32 _counter) public {
+        require(_counter <= 100);
+        require(counters[_from] >= _counter);
+        counters[_from] -= _counter;
+    }
+}
+

--- a/spec/truffle/migrations/1_initial_migration.js
+++ b/spec/truffle/migrations/1_initial_migration.js
@@ -1,0 +1,5 @@
+var Migrations = artifacts.require("./Migrations.sol");
+
+module.exports = function(deployer) {
+  deployer.deploy(Migrations);
+};

--- a/spec/truffle/migrations/2_deploy_contracts.js
+++ b/spec/truffle/migrations/2_deploy_contracts.js
@@ -1,0 +1,11 @@
+var TestContractOne = artifacts.require("./contracts/TestContractOne.sol");
+
+module.exports = function(deployer, network, accounts) {
+    deployer.deploy(TestContractOne)
+	.then(function() {
+		  deployer.logger.log("Deployed TestContractOne at " + TestContractOne.address);
+	      })
+	.catch(function(e) {
+		   deployer.logger.log("error: " + e);
+	       });
+};

--- a/spec/truffle/test/TestContractOne.js
+++ b/spec/truffle/test/TestContractOne.js
@@ -1,0 +1,27 @@
+var TestContractOne = artifacts.require("./contracts/TestContractOne.sol");
+
+contract('TestContractOne', function(accounts) {
+  it("adds and subtracts value", function() {
+	 var tc;
+	 var u = accounts[2];
+	 var initial_counter;
+	 var final_counter;
+
+	 return TestContractOne.deployed()
+	     .then(function(i) {
+		       tc = i;
+		       return tc.counterFor.call(u);
+		   })
+	     .then(function(v) {
+		       initial_counter = v.toNumber();
+		       return tc.addCounter(u, 10);
+		   })
+	     .then(function(r) {
+		       return tc.counterFor.call(u);
+		   })
+	     .then(function(v) {
+		       final_counter = v.toNumber();
+		       assert.equal(final_counter - initial_counter, 10, "counter was not increased correctly");
+		  });
+     });
+});

--- a/spec/truffle/truffle.js
+++ b/spec/truffle/truffle.js
@@ -1,0 +1,21 @@
+module.exports = {
+    networks: {
+	development: {
+	    host: "localhost",
+	    port: 8545,
+	    network_id: "*", // Match any network id
+	    // The sandbox contract used by truffle Solidity testing takes 5741753 gas, so we need to
+	    // set up a large default gas value (I couldn't figure out if and where to set the transaction
+	    // gas for the "before all" hook)
+	    // Note that testrpc also needs to bump its gas limit, for example:
+	    // testrpc -l 6000000
+	    gas: 5900000
+	}
+    },
+    mocha: {
+	reporter: 'spec'
+	// reporter: 'list'
+	// reporter: 'doc'
+	// reporter: 'html'
+    }
+};


### PR DESCRIPTION
Edits to Ethereum::Contract.create to optionally use Truffle artifacts to initialize a contract object.