### PR TITLE
Fix Ethereum::HttpClient

### DIFF
--- a/lib/ethereum/http_client.rb
+++ b/lib/ethereum/http_client.rb
@@ -12,11 +12,7 @@ module Ethereum
       @port = uri.port
       
       @ssl = uri.scheme == 'https'
-#       if ssl
-#         @uri = URI("https://#{@host}:#{@port}")
-#       else
-#         @uri = URI("http://#{@host}:#{@port}")
-#       end
+      @uri = URI("#{uri.scheme}://#{@host}:#{@port}#{uri.path}")
     end
 
     def send_single(payload)

--- a/lib/ethereum/http_client.rb
+++ b/lib/ethereum/http_client.rb
@@ -12,11 +12,11 @@ module Ethereum
       @port = uri.port
       
       @ssl = uri.scheme == 'https'
-      if ssl
-        @uri = URI("https://#{@host}:#{@port}")
-      else
-        @uri = URI("http://#{@host}:#{@port}")
-      end
+#       if ssl
+#         @uri = URI("https://#{@host}:#{@port}")
+#       else
+#         @uri = URI("http://#{@host}:#{@port}")
+#       end
     end
 
     def send_single(payload)


### PR DESCRIPTION
Currently,  `Ethereum::HttpClient.new('http://example.com/testnet')` would initialize an http client with wrong URI (http://example.com), stripping out the path. This PR fixes that.