### PR TITLE
Use pending transaction nonce as a default

### DIFF
--- a/lib/ethereum/client.rb
+++ b/lib/ethereum/client.rb
@@ -73,7 +73,7 @@ module Ethereum
     end
 
     def get_nonce(address)
-      eth_get_transaction_count(address, "latest")["result"].to_i(16)
+      eth_get_transaction_count(address, "pending")["result"].to_i(16)
     end
     
 

--- a/lib/ethereum/contract.rb
+++ b/lib/ethereum/contract.rb
@@ -5,7 +5,7 @@ module Ethereum
 
     attr_reader :address
     attr_accessor :key
-    attr_accessor :gas_limit, :gas_price
+    attr_accessor :gas_limit, :gas_price, :nonce
     attr_accessor :code, :name, :abi, :class_object, :sender, :deployment, :client
     attr_accessor :events, :functions, :constructor_inputs
     attr_accessor :call_raw_proxy, :call_proxy, :transact_proxy, :transact_and_wait_proxy
@@ -247,7 +247,7 @@ module Ethereum
         extend Forwardable
         def_delegators :parent, :deploy_payload, :deploy_args, :call_payload, :call_args
         def_delegators :parent, :signed_deploy, :key, :key=
-        def_delegators :parent, :gas_limit, :gas_price, :gas_limit=, :gas_price=
+        def_delegators :parent, :gas_limit, :gas_price, :gas_limit=, :gas_price=, :nonce, :nonce=
         def_delegators :parent, :abi, :deployment, :events
         def_delegators :parent, :estimate, :deploy, :deploy_and_wait
         def_delegators :parent, :address, :address=, :sender, :sender=

--- a/spec/ethereum/client_spec.rb
+++ b/spec/ethereum/client_spec.rb
@@ -67,7 +67,7 @@ describe Ethereum::Client do
     end
 
     describe ".get_nonce" do
-      let (:request) { {"jsonrpc":"2.0","method":"eth_getTransactionCount","params":["0x407d73d8a49eeb85d32cf465507dd71d507100c1", "latest"],"id":1} }
+      let (:request) { {"jsonrpc":"2.0","method":"eth_getTransactionCount","params":["0x407d73d8a49eeb85d32cf465507dd71d507100c1", "pending"],"id":1} }
       let (:response) { '{"jsonrpc":"2.0","result":"0xd30beea08891180","id":1}' }
       it "returns chain no" do
         expect(client).to receive(:send_single).once.with(request.to_json).and_return(response)


### PR DESCRIPTION
Fixes issues with colliding transactions, additionally allow passing alternate transaction nonce value if needed. Please comment if you see a better solution for sending more than one similar transaction per single mined block.

Relates to: https://github.com/EthWorks/ethereum.rb/issues/35  