### PR TITLE
remove "--add-std" arg, deprecated in solidity 0.4.21

### DIFF
--- a/lib/ethereum/solidity.rb
+++ b/lib/ethereum/solidity.rb
@@ -14,7 +14,7 @@ module Ethereum
 
     def initialize(bin_path = "solc")
       @bin_path = bin_path
-      @args = "--bin --abi --add-std --optimize"
+      @args = "--bin --abi --optimize"
     end
 
     def compile(filename)


### PR DESCRIPTION
--add-std option is removed at solidity 0.4.21.

The compilation is failed with following error.
```
pry(main)> contract =  Ethereum::Contract.create(file: '/tmp/test.sol', client: ipc)
Ethereum::CompilationError: unrecognised option '--add-std'
from /home/iberianpig/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/ethereum.rb-2.1.8/lib/ethereum/solidity.rb:36:in `execute_solc'
```

## version
```
$ solc --version
solc, the solidity compiler commandline interface
Version: 0.4.21+commit.dfe3193c.Linux.g++
```

## refs: 
* https://github.com/ethereum/solidity/issues/3695
* https://github.com/ethereum/solidity/commit/5ab4a1ae7819004415293bf72a86824beb43cd51