### PR TITLE
last of contracts is built by default

### DIFF
--- a/lib/ethereum/contract.rb
+++ b/lib/ethereum/contract.rb
@@ -60,7 +60,7 @@ module Ethereum
         if contract_index
           contract = contracts[contract_index].class_object.new
         else
-          contract = contracts.first.class_object.new
+          contract = contracts.last.class_object.new
         end
       else
         if truffle.present? && truffle.is_a?(Hash)
@@ -301,7 +301,7 @@ module Ethereum
       subpath = File.join('build', 'contracts', "#{name}.json")
 
       found = paths.concat(truffle_paths).find { |p| File.file?(File.join(p, subpath)) }
-      if (found) 
+      if (found)
         JSON.parse(IO.read(File.join(found, subpath)))
       else
         nil


### PR DESCRIPTION
## Problem

Fix https://github.com/EthWorks/ethereum.rb/issues/72

In following case, not expected contract was deployed. I mean, I wanted to deploy B. But accutually A was deployed.

### solidity

```solidity
// 'B.sol'

import './A.sol';

contract B is A {}
```

```solidity
// 'A.sol'

contract A {}
```

## Change

I thought that `last` is better than `first` because a target contract to deploy is written in bottom of a file.