### PR TITLE
namespaces contract classes

### DIFF
--- a/lib/ethereum/contract.rb
+++ b/lib/ethereum/contract.rb
@@ -263,8 +263,8 @@ module Ethereum
           parent
         end
       end
-      Object.send(:remove_const, class_name) if Object.const_defined?(class_name)
-      Object.const_set(class_name, class_methods)
+      Ethereum::Contract.send(:remove_const, class_name) if Ethereum::Contract.const_defined?(class_name)
+      Ethereum::Contract.const_set(class_name, class_methods)
       @class_object = class_methods
     end
 
@@ -301,7 +301,7 @@ module Ethereum
       subpath = File.join('build', 'contracts', "#{name}.json")
 
       found = paths.concat(truffle_paths).find { |p| File.file?(File.join(p, subpath)) }
-      if (found) 
+      if (found)
         JSON.parse(IO.read(File.join(found, subpath)))
       else
         nil

--- a/spec/ethereum/contract_namespacing_spec.rb
+++ b/spec/ethereum/contract_namespacing_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe Ethereum::Contract do
+
+  let(:client) { Ethereum::IpcClient.new }
+  let(:path) { "#{Dir.pwd}/spec/fixtures/TestContract.sol" }
+
+  it "namespaces the generated contract class" do
+    @works = Ethereum::Contract.create(file: path, client: client)
+    expect(@works.parent.class_object.to_s).to eq("Ethereum::Contract::TestContract")
+  end
+
+end


### PR DESCRIPTION
This PR fixes the issue of the generated contract class being defined globally and potentially overriding an existing class. Instead of defining the contract class globally, it is now defined within Ethereum::Contract.