### PR TITLE
Using param name to find contract description when compile from sol file

### DIFF
--- a/lib/ethereum/contract.rb
+++ b/lib/ethereum/contract.rb
@@ -59,6 +59,10 @@ module Ethereum
         raise "No contracts compiled" if contracts.empty?
         if contract_index
           contract = contracts[contract_index].class_object.new
+        elsif name
+          contract = contracts.find{|c| c.name == name}
+          raise "Not found contract with name '#{name}'" unless contract
+          contract = contract.class_object.new
         else
           contract = contracts.first.class_object.new
         end


### PR DESCRIPTION
When there are many contracts in the sol file, then it's better to look for a description by name than by an index that can change