### PR TITLE
Support of Ruby 2.3 has ended.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: trusty
 language: ruby
 rvm:
-  - 2.3.6
   - 2.4.3
   - 2.5.0
 env:


### PR DESCRIPTION
Removed Ruby 2.3 because it is not supported.

```
Ruby 2.3
status: eol
release date: 2015-12-25
EOL date: 2019-03-31
```

* https://www.ruby-lang.org/en/news/2019/03/31/support-of-ruby-2-3-has-ended/
* https://www.ruby-lang.org/en/downloads/branches/