### PR TITLE
Ruby 2.7.0 Released

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ language: ruby
 rvm:
   - 2.4.3
   - 2.5.0
+  - 2.6
+  - 2.7
 env:
   - PARITY="2.5.12"
 cache:


### PR DESCRIPTION
Ruby 2.7.0 Released.
https://www.ruby-lang.org/en/news/2019/12/25/ruby-2-7-0-released/