### PR TITLE
Tested with solc 0.5.16

### DIFF
--- a/PREREQUISITES.md
+++ b/PREREQUISITES.md
@@ -3,7 +3,7 @@
 ## Compatibility and requirements
 
 * Tested with parity 2.5, might work with geth and older parity, but was not tested.
-* Tested with solc 0.5.11
+* Tested with solc 0.5.16
 * Ruby 2.x
 * UNIX/Linux or OS X environment
 

--- a/bin/install_parity
+++ b/bin/install_parity
@@ -5,7 +5,7 @@ sudo add-apt-repository ppa:ethereum/ethereum -y
 sudo apt-get update
 sudo apt-get -y install dpkg
 sudo apt-get -y install libssl-dev
-curl -o /usr/bin/solc -fL https://github.com/ethereum/solidity/releases/download/v0.5.11/solc-static-linux \
+curl -o /usr/bin/solc -fL https://github.com/ethereum/solidity/releases/download/v0.5.16/solc-static-linux \
      && chmod 775 /usr/bin/solc \
      && chown travis:travis /usr/bin/solc
 echo "Solc version"

--- a/spec/ethereum/solidity_spec.rb
+++ b/spec/ethereum/solidity_spec.rb
@@ -3,8 +3,8 @@ require 'spec_helper'
 describe Ethereum::Solidity do
   let (:greeter_bin) { '6080604052348015610010576000' }
   let (:mortal_bin) { '6080604052348015600f57600080' }
-  let (:mortal_abi) { '[{"constant":false,"inputs":[],"name":"kill","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"inputs":[],"payable":false,"stateMutability":"nonpayable","type":"constructor"}]' }
-  let (:greeter_abi) { '[{"constant":false,"inputs":[],"name":"kill","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"},{"constant":true,"inputs":[],"name":"greet","outputs":[{"internalType":"string","name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"string","name":"_greeting","type":"string"}],"payable":false,"stateMutability":"nonpayable","type":"constructor"}]' }
+  let (:mortal_abi) { '[{"inputs":[],"payable":false,"stateMutability":"nonpayable","type":"constructor"},{"constant":false,"inputs":[],"name":"kill","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}]' }
+  let (:greeter_abi) { '[{"inputs":[{"internalType":"string","name":"_greeting","type":"string"}],"payable":false,"stateMutability":"nonpayable","type":"constructor"},{"constant":true,"inputs":[],"name":"greet","outputs":[{"internalType":"string","name":"","type":"string"}],"payable":false,"stateMutability":"view","type":"function"},{"constant":false,"inputs":[],"name":"kill","outputs":[],"payable":false,"stateMutability":"nonpayable","type":"function"}]' }
   let (:contract_path) { "#{Dir.pwd}/spec/fixtures/greeter.sol" }
   let (:compiler_instance) { Ethereum::Solidity.new }
   let (:subject) { compiler_instance.compile(contract_path) }

--- a/spec/fixtures/ContractWithError.sol
+++ b/spec/fixtures/ContractWithError.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.11 <0.6.0;
+pragma solidity >=0.5.16 <0.6.0;
 
 contract ContractWithError {
     faketype name;

--- a/spec/fixtures/TestContract.sol
+++ b/spec/fixtures/TestContract.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.11 <0.6.0;
+pragma solidity >=0.5.16 <0.6.0;
 
 contract TestContract {
 

--- a/spec/fixtures/greeter.sol
+++ b/spec/fixtures/greeter.sol
@@ -1,4 +1,4 @@
-pragma solidity >=0.5.11 <0.6.0;
+pragma solidity >=0.5.16 <0.6.0;
 
 contract mortal {
     /* Define variable owner of the type address*/


### PR DESCRIPTION
I'm upgrade solc version to [0.5.16](https://github.com/ethereum/solidity/releases/tag/v0.5.16).
In solc 0.5.12 has been changed sort order of JSON ABI.

> ABI Output: Change sorting order of functions from selector to kind, name.

see: https://github.com/ethereum/solidity/releases/tag/v0.5.12

