### PR TITLE
BigDecimal.new is deprecated in Ruby 2.7

### DIFF
--- a/lib/ethereum/formatter.rb
+++ b/lib/ethereum/formatter.rb
@@ -73,12 +73,12 @@ module Ethereum
 
     def to_wei(amount, unit = "ether")
       return nil if amount.nil?
-      BigDecimal.new(UNITS[unit.to_sym] * amount, 16).to_s.to_i rescue nil
+      BigDecimal(UNITS[unit.to_sym] * amount, 16).to_s.to_i rescue nil
     end
 
     def from_wei(amount, unit = "ether")
       return nil if amount.nil?
-      (BigDecimal.new(amount, 16) / BigDecimal.new(UNITS[unit.to_sym], 16)).to_s rescue nil
+      (BigDecimal(amount, 16) / BigDecimal(UNITS[unit.to_sym], 16)).to_s rescue nil
     end
 
     def from_address(address)

--- a/spec/ethereum/formatter_spec.rb
+++ b/spec/ethereum/formatter_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe Ethereum::Formatter do
+
+  let (:formatter) { Ethereum::Formatter.new }
+
+  it "#to_wei" do
+    expect(formatter.to_wei(1)).to eq 1000000000000000000
+    expect(formatter.to_wei(nil)).to be_nil
+  end
+
+  it "#from_wei" do
+    expect(formatter.from_wei(1000000000000000000)).to eq "1.0"
+    expect(formatter.from_wei(nil)).to be_nil
+  end
+end


### PR DESCRIPTION

fix: https://github.com/EthWorks/ethereum.rb/issues/139