### PR TITLE
Fix allowance of passing alternate transaction nonce value on contract

### DIFF
--- a/lib/ethereum/contract.rb
+++ b/lib/ethereum/contract.rb
@@ -120,7 +120,7 @@ module Ethereum
 
     def send_raw_transaction(payload, to = nil)
       Eth.configure { |c| c.chain_id = @client.net_version["result"].to_i }
-      @nonce = @client.get_nonce(key.address)
+      @nonce ||= @client.get_nonce(key.address)
       args = {
         from: key.address,
         value: 0,


### PR DESCRIPTION
Fixes ability of changing nonce which is introduced by https://github.com/EthWorks/ethereum.rb/pull/58, and later it seems to be removed by https://github.com/EthWorks/ethereum.rb/pull/112