### PR TITLE
Feature: Can now make calls to anterior states

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,16 @@ contract.gas_limit = 2_000_000_
 contract.gas_price = 24_000_000_000
 ```
 
+### Custom block
+
+You can change the block used by the client. Defaulted at `'latest'` if not specified.
+If the specified block is older than the latest, transactions are impossible, and only contract `call` are available, as the blockchain is immutable.
+
+```ruby
+client.block_number = 12_596_089
+```
+
+
 ## Utils
 
 ### Url helpers for rails applications

--- a/lib/ethereum/client.rb
+++ b/lib/ethereum/client.rb
@@ -1,9 +1,9 @@
 module Ethereum
   class Client
 
-    DEFAULT_GAS_LIMIT = 4_000_000
-
-    DEFAULT_GAS_PRICE = 22_000_000_000
+    DEFAULT_GAS_LIMIT    = 4_000_000.freeze
+    DEFAULT_GAS_PRICE    = 22_000_000_000.freeze
+    DEFAULT_BLOCK_NUMBER = 'latest'.freeze
 
     # https://github.com/ethereum/wiki/wiki/JSON-RPC
     RPC_COMMANDS = %w(web3_clientVersion web3_sha3 net_version net_peerCount net_listening eth_protocolVersion eth_syncing eth_coinbase eth_mining eth_hashrate eth_gasPrice eth_accounts eth_blockNumber eth_getBalance eth_getStorageAt eth_getTransactionCount eth_getBlockTransactionCountByHash eth_getBlockTransactionCountByNumber eth_getUncleCountByBlockHash eth_getUncleCountByBlockNumber eth_getCode eth_sign eth_sendTransaction eth_sendRawTransaction eth_call eth_estimateGas eth_getBlockByHash eth_getBlockByNumber eth_getTransactionByHash eth_getTransactionByBlockHashAndIndex eth_getTransactionByBlockNumberAndIndex eth_getTransactionReceipt eth_getUncleByBlockHashAndIndex eth_getUncleByBlockNumberAndIndex eth_getCompilers eth_compileLLL eth_compileSolidity eth_compileSerpent eth_newFilter eth_newBlockFilter eth_newPendingTransactionFilter eth_uninstallFilter eth_getFilterChanges eth_getFilterLogs eth_getLogs eth_getWork eth_submitWork eth_submitHashrate db_putString db_getString db_putHex db_getHex shh_post shh_version shh_newIdentity shh_hasIdentity shh_newGroup shh_addToGroup shh_newFilter shh_uninstallFilter shh_getFilterChanges shh_getMessages)
@@ -11,15 +11,17 @@ module Ethereum
     # https://github.com/ethereum/go-ethereum/wiki/Management-APIs
     RPC_MANAGEMENT_COMMANDS = %w(admin_addPeer admin_datadir admin_nodeInfo admin_peers admin_setSolc admin_startRPC admin_startWS admin_stopRPC admin_stopWS debug_backtraceAt debug_blockProfile debug_cpuProfile debug_dumpBlock debug_gcStats debug_getBlockRlp debug_goTrace debug_memStats debug_seedHash debug_setHead debug_setBlockProfileRate debug_stacks debug_startCPUProfile debug_startGoTrace debug_stopCPUProfile debug_stopGoTrace debug_traceBlock debug_traceBlockByNumber debug_traceBlockByHash debug_traceBlockFromFile debug_traceTransaction debug_verbosity debug_vmodule debug_writeBlockProfile debug_writeMemProfile miner_hashrate miner_makeDAG miner_setExtra miner_setGasPrice miner_start miner_startAutoDAG miner_stop miner_stopAutoDAG personal_importRawKey personal_listAccounts personal_lockAccount personal_newAccount personal_unlockAccount personal_sendTransaction txpool_content txpool_inspect txpool_status)
 
-    attr_accessor :command, :id, :log, :logger, :default_account, :gas_price, :gas_limit
+    attr_accessor :command, :id, :log, :logger, :default_account, :gas_price, :gas_limit, :block_number
 
     def initialize(log = false)
-      @id = 0
-      @log = log
-      @batch = nil
-      @formatter = Ethereum::Formatter.new
-      @gas_price = DEFAULT_GAS_PRICE
-      @gas_limit = DEFAULT_GAS_LIMIT
+      @id           = 0
+      @log          = log
+      @batch        = nil
+      @formatter    = ::Ethereum::Formatter.new
+      @gas_price    = DEFAULT_GAS_PRICE
+      @gas_limit    = DEFAULT_GAS_LIMIT
+      @block_number = DEFAULT_BLOCK_NUMBER
+
       if @log == true
         @logger = Logger.new("/tmp/ethereum_ruby_http.log")
       end
@@ -114,7 +116,7 @@ module Ethereum
 
     def send_command(command,args)
       if ["eth_getBalance", "eth_call"].include?(command)
-        args << "latest"
+        args << block_number
       end
 
       payload = {jsonrpc: "2.0", method: command, params: encode_params(args), id: get_id}

--- a/lib/ethereum/contract.rb
+++ b/lib/ethereum/contract.rb
@@ -1,5 +1,4 @@
 require 'forwardable'
-
 module Ethereum
   class Contract
 
@@ -166,7 +165,9 @@ module Ethereum
     end
 
     def call_args(fun, args)
-      add_gas_options_args({to: @address, from: @sender, data: call_payload(fun, args)})
+      options = {to: @address, from: @sender, data: call_payload(fun, args)}
+
+      fun.constant ? options : add_gas_options_args(options)
     end
 
     def call_raw(fun, *args)

--- a/lib/ethereum/ipc_client.rb
+++ b/lib/ethereum/ipc_client.rb
@@ -22,7 +22,7 @@ module Ethereum
     end
 
     def self.default_path(paths = IPC_PATHS)
-      path = paths.select { |path| File.exist?(path) }.first
+      path = paths.find { |path| File.exist?(path) }
       path || raise("Ipc file not found. Please pass in the file path explicitly to IpcClient initializer")
     end
 

--- a/lib/ethereum/version.rb
+++ b/lib/ethereum/version.rb
@@ -1,3 +1,3 @@
 module Ethereum
-  VERSION = "2.5"
+  VERSION = "2.5.2"
 end

--- a/spec/ethereum/contract_spec.rb
+++ b/spec/ethereum/contract_spec.rb
@@ -88,64 +88,85 @@ describe Ethereum::Contract do
   end
 
   context "transact" do
-    let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0xcfae32170000000000000000000000000000000000000000000000000000000000000000"}],"id":1}' }
+    let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0x41c0e1b50000000000000000000000000000000000000000000000000000000000000000"}],"id":1}' }
     let(:eth_send_result) { '{"jsonrpc":"2.0","result":"0x2736d20b6e8698225c298fba56a90c0c6e95699f95e9c0b13909a730ea438623","id":1}' }
-    subject { expect(contract.transact.greet.id).to eq '0x2736d20b6e8698225c298fba56a90c0c6e95699f95e9c0b13909a730ea438623' }
+    subject { expect(contract.transact.kill.id).to eq '0x2736d20b6e8698225c298fba56a90c0c6e95699f95e9c0b13909a730ea438623' }
     it_behaves_like "communicate with node"
   end
 
   context "transact with custom gas" do
-    let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0xcfae32170000000000000000000000000000000000000000000000000000000000000000","gas":"0xabe0"}],"id":1}' }
+    let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0x41c0e1b50000000000000000000000000000000000000000000000000000000000000000","gas":"0xabe0"}],"id":1}' }
     let(:eth_send_result) { '{"jsonrpc":"2.0","result":"0x2736d20b6e8698225c298fba56a90c0c6e95699f95e9c0b13909a730ea438623","id":1}' }
     it "communicate with node" do
       expect(client).to receive(:send_single).once.with(eth_send_request).and_return(eth_send_result)
       contract.gas_limit = 44000
-      expect(contract.transact.greet.id).to eq '0x2736d20b6e8698225c298fba56a90c0c6e95699f95e9c0b13909a730ea438623'
+      expect(contract.transact.kill.id).to eq '0x2736d20b6e8698225c298fba56a90c0c6e95699f95e9c0b13909a730ea438623'
     end
   end
 
   context "transact with custom gas price" do
-    let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0xcfae32170000000000000000000000000000000000000000000000000000000000000000","gasPrice":"0xabe0"}],"id":1}' }
+    let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0x41c0e1b50000000000000000000000000000000000000000000000000000000000000000","gasPrice":"0xabe0"}],"id":1}' }
     let(:eth_send_result) { '{"jsonrpc":"2.0","result":"0x2736d20b6e8698225c298fba56a90c0c6e95699f95e9c0b13909a730ea438623","id":1}' }
     it "communicate with node" do
       expect(client).to receive(:send_single).once.with(eth_send_request).and_return(eth_send_result)
       contract.gas_price = 44000
-      expect(contract.transact.greet.id).to eq '0x2736d20b6e8698225c298fba56a90c0c6e95699f95e9c0b13909a730ea438623'
+      expect(contract.transact.kill.id).to eq '0x2736d20b6e8698225c298fba56a90c0c6e95699f95e9c0b13909a730ea438623'
     end
   end
 
   context "transact with insufficient funds" do
-    let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0xcfae32170000000000000000000000000000000000000000000000000000000000000000"}],"id":1}' }
+    let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0x41c0e1b50000000000000000000000000000000000000000000000000000000000000000"}],"id":1}' }
     it "communicate with node" do
       expect(client).to receive(:send_single).once.with(eth_send_request).and_return(insufficient_funds_result)
-      expect{ contract.transact.greet }.to raise_error(IOError, "Insufficient funds. The account you tried to send transaction from does not have enough funds.")
+      expect{ contract.transact.kill }.to raise_error(IOError, "Insufficient funds. The account you tried to send transaction from does not have enough funds.")
     end
   end
 
   context "transact_and_wait" do
-    let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0xcfae32170000000000000000000000000000000000000000000000000000000000000000"}],"id":1}' }
+    let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_sendTransaction","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0x41c0e1b50000000000000000000000000000000000000000000000000000000000000000"}],"id":1}' }
     let(:eth_get_transaction_request) { '{"jsonrpc":"2.0","method":"eth_getTransactionByHash","params":[""],"id":1}' }
     let(:eth_get_transaction_result) { '{"jsonrpc":"2.0","result":{"blockHash":"0xc1e5032da79990789fb6933d31fb5670e66aec1e88fa98efbc1c9d4507c070ab","blockNumber":"0x56893","creates":null,"from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","gas":"0xe57e0","gasPrice":"0x4a817c800","hash":"0x528b3c18433ea9b9089f0eef1f5be722934e629e441fa1af07f33531b20c22c9","input":"0x41c0e1b5","nonce":"0x25","publicKey":"0xccfdb8fdcf107fa9aa3fbaef7bc33c97685a7ab61f9cbef8e510fff848930b444e0ae2e66b27326b95cab0ff070c1db793f396c646ae2cb17ad539f41af23099","r":"0x07139d16062f86f003836a6b41ff2fba5c8988daa745c44cddeb807f7c5dee5e","raw":"0xf869258504a817c800830e57e0945b1141d29fad616d221fff559dcaa11bbb2ebcb7808441c0e1b52aa007139d16062f86f003836a6b41ff2fba5c8988daa745c44cddeb807f7c5dee5ea0415b0bdbc6bee69a8e6518abe914ae29a4f0a4a23f7aa9683f4fe5b16bafc0d9","s":"0x415b0bdbc6bee69a8e6518abe914ae29a4f0a4a23f7aa9683f4fe5b16bafc0d9","to":"0x5b1141d29fad616d221fff559dcaa11bbb2ebcb7","transactionIndex":"0x3","v":1,"value":"0x0"},"id":1}' }
     it "communicate with node" do
       expect(client).to receive(:send_single).once.with(eth_send_request).and_return(eth_send_result)
       expect(client).to receive(:send_single).once.with(eth_get_transaction_request).and_return(eth_get_transaction_result)
-      contract.transact_and_wait.greet
+      contract.transact_and_wait.kill
     end
   end
 
-  context "call" do
-    let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0xcfae32170000000000000000000000000000000000000000000000000000000000000000"},"latest"],"id":1}' }
-    let(:eth_send_result) { '{"jsonrpc":"2.0", "result": "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003616c610000000000000000000000000000000000000000000000000000000000", "id": 1}' }
-    subject { expect(contract.call.greet).to eq "ala" }
-    it_behaves_like "communicate with node"
+  context "current block" do
+    describe "#call" do
+      let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0xcfae32170000000000000000000000000000000000000000000000000000000000000000"},"latest"],"id":1}' }
+      let(:eth_send_result) { '{"jsonrpc":"2.0", "result": "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003616c610000000000000000000000000000000000000000000000000000000000", "id": 1}' }
+      subject { expect(contract.call.greet).to eq "ala" }
+      it_behaves_like "communicate with node"
+    end
+
+    describe "#call_raw" do
+      let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0xcfae32170000000000000000000000000000000000000000000000000000000000000000"},"latest"],"id":1}' }
+      let(:eth_send_result) { '{"jsonrpc":"2.0", "result": "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003616c610000000000000000000000000000000000000000000000000000000000", "id": 1}' }
+      subject { expect(contract.call_raw.greet[:formatted]).to eq ["ala"] }
+      it_behaves_like "communicate with node"
+    end
   end
 
-  context "call_raw" do
-    let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0xcfae32170000000000000000000000000000000000000000000000000000000000000000"},"latest"],"id":1}' }
-    let(:eth_send_result) { '{"jsonrpc":"2.0", "result": "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003616c610000000000000000000000000000000000000000000000000000000000", "id": 1}' }
-    subject { expect(contract.call_raw.greet[:formatted]).to eq ["ala"] }
-    it_behaves_like "communicate with node"
+  context "old block" do
+    before { client.block_number = 1 }
+
+    describe "#call" do
+      let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0xcfae32170000000000000000000000000000000000000000000000000000000000000000"},"0x1"],"id":1}' }
+      let(:eth_send_result) { '{"jsonrpc":"2.0", "result": "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003616c610000000000000000000000000000000000000000000000000000000000", "id": 1}' }
+      subject { expect(contract.call.greet).to eq "ala" }
+      it_behaves_like "communicate with node"
+    end
+
+    describe "#call_raw" do
+      let(:eth_send_request) { '{"jsonrpc":"2.0","method":"eth_call","params":[{"to":"0xaf83b6f1162062aa6711de633821f3e66b6fb3a5","from":"0x27dcb234fab8190e53e2d949d7b2c37411efb72e","data":"0xcfae32170000000000000000000000000000000000000000000000000000000000000000"},"0x1"],"id":1}' }
+      let(:eth_send_result) { '{"jsonrpc":"2.0", "result": "0x00000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000003616c610000000000000000000000000000000000000000000000000000000000", "id": 1}' }
+      subject { expect(contract.call_raw.greet[:formatted]).to eq ["ala"] }
+      it_behaves_like "communicate with node"
+    end
   end
+
 
   context "truffle" do
     let(:tpaths) { [ './spec/truffle' ] }


### PR DESCRIPTION
Now add the possibility to specify a specific block. `latest` was previously hardcoded in the codebase and did not allow us to use an anterior state of the blockchain. This pull request now enables it.

Updated the documentation. Pretty straightforward, the user can now specify it directly to the client:

For example:

```ruby
client.block_number = 2
```

https://eth.wiki/json-rpc/API#eth_call

It is refered in the documentation as `QUANTITY|TAG`, but I prefer to refer it as `block_number` out of convenience.

Also, during `call` of constant functions, the gas should not be specified. Somehow this bug impeded the good working of making calls with old block numbers. Each time that a call was made, the gas was specified even though it was not needed.