### PR TITLE
gems: bump dependencies

### DIFF
--- a/ethereum.gemspec
+++ b/ethereum.gemspec
@@ -33,5 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "ffi", "~> 1.15"
 
   spec.add_dependency "activesupport", ">= 4.2"
-  spec.add_dependency "keccak", "~> 1.2"
+  spec.add_dependency "keccak", "~> 1.3"
 end

--- a/ethereum.gemspec
+++ b/ethereum.gemspec
@@ -25,12 +25,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib", "bin"]
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 12.0"
-  spec.add_development_dependency "rspec", "~> 3.5"
-  spec.add_development_dependency "pry", "~> 0.10"
-  spec.add_development_dependency "eth-patched", "~> 0.4"
+  spec.add_development_dependency "bundler", "~> 2.2"
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.10"
+  spec.add_development_dependency "pry", "~> 0.14"
+  spec.add_development_dependency "eth", "~> 0.4"
+  spec.add_development_dependency "ffi", "~> 1.15"
 
-  spec.add_dependency "activesupport", ">= 4.0"
-  spec.add_dependency "digest-sha3", "~> 1.1"
+  spec.add_dependency "activesupport", ">= 4.2"
+  spec.add_dependency "keccak", "~> 1.2"
 end

--- a/lib/ethereum.rb
+++ b/lib/ethereum.rb
@@ -1,7 +1,7 @@
 require "ethereum/version"
 require 'active_support'
 require 'active_support/core_ext'
-require 'digest/sha3'
+require 'digest/keccak'
 
 module Ethereum
   require 'ethereum/abi'

--- a/lib/ethereum/contract_event.rb
+++ b/lib/ethereum/contract_event.rb
@@ -8,7 +8,7 @@ module Ethereum
       @input_types = data["inputs"].collect {|x| x["type"]}
       @inputs = data["inputs"].collect {|x| x["name"]}
       @event_string = "#{@name}(#{@input_types.join(",")})"
-      @signature = Digest::SHA3.hexdigest(@event_string, 256)
+      @signature = Digest::Keccak.hexdigest(@event_string, 256)
     end
 
     def set_address(address)
@@ -21,4 +21,3 @@ module Ethereum
 
   end
 end
-

--- a/lib/ethereum/function.rb
+++ b/lib/ethereum/function.rb
@@ -1,7 +1,7 @@
 module Ethereum
   class Function
 
-    attr_accessor :name, :inputs, :outputs, :signature, :constant, :function_string 
+    attr_accessor :name, :inputs, :outputs, :signature, :constant, :function_string
 
     def initialize(data)
       @name = data["name"]
@@ -29,7 +29,7 @@ module Ethereum
     end
 
     def self.calc_id(signature)
-      Digest::SHA3.hexdigest(signature, 256)[0..7]
+      Digest::Keccak.hexdigest(signature, 256)[0..7]
     end
 
   end


### PR DESCRIPTION
- replaces `eth-patched` with `eth` (reverts #165) - I'm co-maintainer now
- replaces `digest-sha3` (unmaintained) with `keccak` - I'm maintaining that one too
- adds `ffi` (couldn't get `rspec` to work without)
- bumped `rake` to 13.0
- bumped some minor versions