### PR TITLE
Adds Ruby 3 support by moving from digest-sha3 to keccak

### DIFF
--- a/ethereum.gemspec
+++ b/ethereum.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "eth-patched", "~> 0.4"
 
   spec.add_dependency "activesupport", ">= 4.0"
-  spec.add_dependency "keccak.rb", "~> 1.2"
+  spec.add_dependency "keccak", "~> 1.2"
 end

--- a/ethereum.gemspec
+++ b/ethereum.gemspec
@@ -32,5 +32,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "eth-patched", "~> 0.4"
 
   spec.add_dependency "activesupport", ">= 4.0"
-  spec.add_dependency "digest-sha3", "~> 1.1"
+  spec.add_dependency "keccak.rb", "~> 1.2"
 end

--- a/lib/ethereum.rb
+++ b/lib/ethereum.rb
@@ -1,7 +1,7 @@
 require "ethereum/version"
 require 'active_support'
 require 'active_support/core_ext'
-require 'keccak'
+require 'digest/keccak'
 
 module Ethereum
   require 'ethereum/abi'

--- a/lib/ethereum.rb
+++ b/lib/ethereum.rb
@@ -1,7 +1,7 @@
 require "ethereum/version"
 require 'active_support'
 require 'active_support/core_ext'
-require 'digest/sha3'
+require 'keccak'
 
 module Ethereum
   require 'ethereum/abi'


### PR DESCRIPTION
`digest-sha3` is no longer being maintained, and a new project, `keccak` has taken its place.

Keccak gem: https://github.com/q9f/keccak.rb

This PR updates the dependency to be compatible with Ruby 3 by upgrading this dependency.