### PR TITLE
fix the valid_address? method and add specs

### DIFF
--- a/lib/ethereum/formatter.rb
+++ b/lib/ethereum/formatter.rb
@@ -29,11 +29,9 @@ module Ethereum
       tether:     1000000000000000000000000000000
     }
 
-    def valid_address?(address_string)
-      address = address_string.gsub(/^0x/,'')
-      return false if address == "0000000000000000000000000000000000000000"
-      return false if address.length != 40
-      return !(address.match(/[0-9a-fA-F]+/).nil?)
+    def valid_address?(address)
+      return false if address == "0x0000000000000000000000000000000000000000"
+      return !(address.match(/^0x[0-9a-fA-F]{40}$/).nil?)
     end
 
     def from_bool(boolval)

--- a/spec/ethereum/formatter_spec.rb
+++ b/spec/ethereum/formatter_spec.rb
@@ -13,4 +13,30 @@ describe Ethereum::Formatter do
     expect(formatter.from_wei(1000000000000000000)).to eq "1.0"
     expect(formatter.from_wei(nil)).to be_nil
   end
+
+  context "#valid_address?" do
+    it "with a null address" do
+      expect(formatter.valid_address?("0x0000000000000000000000000000000000000000")).to eq false
+    end
+
+    it "with an address of 40 hexadecimal characters" do
+      expect(formatter.valid_address?("0x9C11541DD6f927e9A8eeEe7D9d205c1061C88aB8")).to eq true
+    end
+
+    it "with an address of less than 40 hexadecimal characters" do
+      expect(formatter.valid_address?("0x9C11541DD6f927e9A8eeEe7D9d205c1061C88aB")).to eq false
+    end
+
+    it "with an address of more than 40 hexadecimal characters" do
+      expect(formatter.valid_address?("0x9C11541DD6f927e9A8eeEe7D9d205c1061C88aB81")).to eq false
+    end
+
+    it "with an address of 40 characters (but non-hexadecimal characters included at the end)" do
+      expect(formatter.valid_address?("0x9C11541DD6f927e9A8eeEe7D9d205c1061C88aB*")).to eq false
+    end
+
+    it "with an address of 40 characters (but non-hexadecimal characters included at the middle)" do
+      expect(formatter.valid_address?("0x9C11541DD6f927e9A8*eEe7D9d205c1061C88aB8")).to eq false
+    end
+  end
 end


### PR DESCRIPTION
This fixes the address formatter for the following previously unspecified cases.

```
Failures:

  1) Ethereum::Formatter#valid_address? with an address of 40 characters (but non-hexadecimal characters included at the end)
     Failure/Error: expect(formatter.valid_address?("0x9C11541DD6f927e9A8eeEe7D9d205c1061C88aB*")).to eq false
     
       expected: false
            got: true
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -false
       +true
       
     # ./spec/ethereum/formatter_spec.rb:35:in `block (3 levels) in <top (required)>'

  2) Ethereum::Formatter#valid_address? with an address of 40 characters (but non-hexadecimal characters included at the middle)
     Failure/Error: expect(formatter.valid_address?("0x9C11541DD6f927e9A8*eEe7D9d205c1061C88aB8")).to eq false
     
       expected: false
            got: true
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -false
       +true
       
     # ./spec/ethereum/formatter_spec.rb:39:in `block (3 levels) in <top (required)>'
```

I also am wondering why we are considering the null address not a valid address.  I recommend we remove the line

`return false if address == "0x0000000000000000000000000000000000000000"` from

```
   def valid_address?(address)
      return false if address == "0x0000000000000000000000000000000000000000"
      return !(address.match(/^0x[0-9a-fA-F]{40}$/).nil?)
    end
```